### PR TITLE
Include product_id in submitted data

### DIFF
--- a/assets/js/woo-enquiry-front-script.js
+++ b/assets/js/woo-enquiry-front-script.js
@@ -13,7 +13,8 @@ jQuery("body").on("click", ".wqoecf_enquiry_button", function () {
         type: 'POST',
         url: wqoecfObj.ajaxurl,
         data: {
-            'action': 'wqoecf_enquiry_popup'
+            'action': 'wqoecf_enquiry_popup',
+            'product_id' : product_id
         },
         dataType: 'json',
         success: function (response) {


### PR DESCRIPTION
Revert the very old functionality that made product_id available. This will provide the product ID to custom CF7 shortcodes.

I wrote custom CF7 shortcodes (that work with CF7 Dynamic Text Extension). They use $_POST[product_id] and used to work with this plugin but are broken now. Submitting product_id will fix them.
https://www.damiencarbery.com/2019/11/shortcode-for-contact-form-7-dynamic-text-extension/